### PR TITLE
fix(examples): fix outputs.tf module reference from module.ess to module.ess-clb to match declared module call

### DIFF
--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -1,4 +1,4 @@
 output "scaling_group_id" {
   description = "The Scaling Group ID"
-  value       = module.ess.scaling_group_id
+  value       = module.ess-clb.scaling_group_id
 }


### PR DESCRIPTION
## Summary
- Fix `Reference to undeclared module` error in `examples/complete/outputs.tf`
- Change `module.ess.scaling_group_id` to `module.ess-clb.scaling_group_id` to match the actual module call name in `main.tf`

## Root Cause
The example's `outputs.tf` referenced `module.ess` but `main.tf` declares the module as `module "ess-clb"`, causing a Plan-time failure.

## Test Plan
- [x] `terraform fmt -check` passes on modified file
- [x] `tflint --recursive` passes
- [x] `terraform init -upgrade && terraform validate` passes for `examples/complete`